### PR TITLE
FIX: Fix error for slashs in subtitle and version

### DIFF
--- a/qlikutils/__main__.py
+++ b/qlikutils/__main__.py
@@ -1,4 +1,4 @@
-from .utils import draw_texts, resize_image, BASE_DIR
+from .utils import draw_texts, resize_image, get_file_name, BASE_DIR
 from PIL import Image
 import argparse
 import re
@@ -40,8 +40,9 @@ if __name__ == "__main__":
 
     if not os.path.exists(args.output_dir):
         os.makedirs(args.output_dir)
-    project_name = args.title.strip().replace(" ", "_").replace("\\", "").replace("/", "")
-    filepath = f'{args.output_dir}/{project_name}_{args.subtitle}_thumbnail_{args.version}.png'
+
+    project_name = get_file_name(args.title, args.subtitle, args.version)
+    filepath = f'{args.output_dir}/{project_name}'
     final_img.save(filepath)
 
     if platform.system() == "Darwin":  # macOS

--- a/qlikutils/utils.py
+++ b/qlikutils/utils.py
@@ -4,6 +4,23 @@ from unidecode import unidecode
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
+def get_file_name(title: str, subtitle: str, version: str) -> str:
+    """
+    Get the file name based on the title, subtitle and version.
+    
+    Args:
+        title (str): The project title.
+        subtitle (str): The project subtitle.
+        version (str): The project version.
+
+    Returns:
+        str: The file name with png extension.
+    """
+    project_name = title.strip().replace(" ", "_").replace("\\", "").replace("/", "")
+    subtitle_name = subtitle.strip().replace(" ", "_").replace("\\", "").replace("/", "")
+    version_name = version.strip().replace(" ", "_").replace("\\", "").replace("/", "")
+    return f'{project_name}_{subtitle_name}_thumbnail_{version_name}.png'
+
 def parse_color(value):
     value = value.lstrip('#')  # Remove the '#' character if present
     length = len(value)


### PR DESCRIPTION
The previous code version removed slashs only for title. This version:

- Remove slashs for title, subtitle and version. (All variables that is used to create the file name)
- Create a function to get the file name, allowing to import it in a python project with ```from qlikutils.utils import get_file_name```